### PR TITLE
SEO, blog, checkout, and content improvements

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { posts, getPostBySlug, formatDate } from '@/lib/posts';
 
 interface Props {
@@ -71,9 +73,14 @@ export default async function BlogPost({ params }: Props) {
             prose-li:text-text-secondary
             prose-a:text-[#5B5CF6] prose-a:no-underline hover:prose-a:underline
             prose-strong:text-text-primary
-            prose-ul:my-4"
-          dangerouslySetInnerHTML={{ __html: post.content }}
-        />
+            prose-ul:my-4
+            prose-table:border-collapse prose-th:border prose-th:border-gray-200 prose-th:bg-gray-50 prose-th:px-4 prose-th:py-2
+            prose-td:border prose-td:border-gray-200 prose-td:px-4 prose-td:py-2"
+        >
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {post.content}
+          </ReactMarkdown>
+        </div>
 
         {/* CTA */}
         <div className="mt-16 rounded-3xl border border-[#CBD2FF] bg-gradient-to-br from-[#F0F0FF] to-[#EAF1FF] p-8 text-center">

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,8 @@
         "next": "16.1.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -223,17 +225,29 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/react": ["@types/react@19.2.13", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.55.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.55.0", "@typescript-eslint/type-utils": "8.55.0", "@typescript-eslint/utils": "8.55.0", "@typescript-eslint/visitor-keys": "8.55.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.55.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ=="],
 
@@ -254,6 +268,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.55.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.55.0", "@typescript-eslint/types": "8.55.0", "@typescript-eslint/typescript-estree": "8.55.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.55.0", "", { "dependencies": { "@typescript-eslint/types": "8.55.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@unrs/resolver-binding-android-arm-eabi": ["@unrs/resolver-binding-android-arm-eabi@1.11.1", "", { "os": "android", "cpu": "arm" }, "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw=="],
 
@@ -331,6 +347,8 @@
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": "dist/cli.js" }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
@@ -351,13 +369,25 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001769", "", {}, "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -377,13 +407,19 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
@@ -445,7 +481,11 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -513,9 +553,15 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -523,7 +569,13 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -543,6 +595,8 @@
 
     "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
 
+    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
@@ -551,6 +605,8 @@
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
 
     "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
@@ -558,6 +614,8 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
@@ -637,6 +695,8 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": "cli.js" }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -645,9 +705,97 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -693,6 +841,8 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
+    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -711,6 +861,8 @@
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -721,9 +873,19 @@
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -767,6 +929,8 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
@@ -783,9 +947,15 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
@@ -800,6 +970,10 @@
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
@@ -825,11 +999,27 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -851,11 +1041,9 @@
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
-
-    "@babel/core/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -875,15 +1063,17 @@
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
-    "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "is-bun-module/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -4,7 +4,7 @@ export interface Post {
   description: string;
   date: string;
   readTime: string;
-  content: string;
+  content: string; // markdown
 }
 
 export const posts: Post[] = [
@@ -16,48 +16,42 @@ export const posts: Post[] = [
     date: '2026-04-10',
     readTime: '6 min read',
     content: `
-<p>If you publish on LinkedIn regularly, you've probably stitched together your own workflow: ChatGPT for drafting, Notion for storing ideas, Buffer or Hootsuite for scheduling, maybe a separate analytics tool to check what's working. It gets the job done — until it doesn't.</p>
+You've got ChatGPT for drafting, Notion for storing ideas, Buffer for scheduling, and a spreadsheet for tracking what's working. It kind of works — until it doesn't.
 
-<p>The problem isn't any single tool. It's the friction between them. Every handoff between tools costs time, breaks momentum, and introduces inconsistency. You paste text into the wrong window, lose a draft, or forget to cross-reference your analytics before writing the next post.</p>
+**The problem isn't your tools. It's the gap between them.**
 
-<p>In 2026, the better answer is a dedicated <strong>AI LinkedIn workspace</strong> — a single environment where every step from idea to published post happens without leaving the platform.</p>
+Every time you copy-paste between apps, you lose momentum. You forget to check analytics before writing the next post. You leave a draft half-finished in the wrong tab. Multiply that by five posts a week and it becomes a real drag.
 
-<h2>The Patchwork Approach vs. an Integrated Workspace</h2>
+## The two types of LinkedIn creators
 
-<p>Most LinkedIn creators fall into one of two camps:</p>
+**The patchwork crew** stitches together general-purpose tools. ChatGPT drafts it, Notion stores it, Buffer publishes it, and a separate dashboard tracks it. Works fine at low volume. Falls apart when you're posting consistently.
 
-<p><strong>The patchwork camp</strong> uses a combination of general-purpose AI tools alongside social media schedulers. ChatGPT or Claude generates a draft, which gets copied into Notion or Google Docs for editing, then manually pasted into a scheduler like Buffer, then posted — and tracked separately in a spreadsheet or native LinkedIn analytics.</p>
+**The integrated crew** uses a purpose-built **AI LinkedIn workspace** — one place where research, drafting, editing, scheduling, and analytics all live. Less friction. More posts. Better results.
 
-<p>This works at low volume. Once you're posting 3–5 times a week, managing multiple accounts, or working with a content team, the overhead compounds fast.</p>
+## What actually matters in an AI LinkedIn workspace
 
-<p><strong>The integrated camp</strong> uses a purpose-built AI LinkedIn workspace. Research, drafting, editing, scheduling, and analytics live in one place. The AI is trained on LinkedIn-specific formats — not generic blog posts or email copy — so the output is more immediately usable.</p>
+Not every tool that calls itself a "workspace" earns the label. Here's what to look for:
 
-<h2>What to Look for in an AI LinkedIn Workspace</h2>
+- **LinkedIn-native AI** — General AI writes generic content. A workspace trained on LinkedIn formats produces drafts that actually sound like LinkedIn posts, not blog excerpts.
+- **Real multi-account support** — If you manage more than one profile, you need a single dashboard. Not a dropdown with three separate login flows.
+- **Scheduling built in** — Any tool that makes you export to a separate scheduler is not a workspace. It's two tools with extra steps.
+- **Analytics that inform your next post** — Not just a scorecard. The data should be visible *while* you're writing.
+- **A free tier that's actually usable** — You should be able to validate the workflow before paying anything.
 
-<p>Not all tools that call themselves AI LinkedIn workspaces are created equal. Here's what to evaluate:</p>
+## How Marquill handles this
 
-<ul>
-  <li><strong>LinkedIn-native AI:</strong> General AI models produce generic content. A workspace trained on what actually performs on LinkedIn — hooks, formatting, post length, cadence — produces drafts that need less editing before they're ready to publish.</li>
-  <li><strong>Multi-account support:</strong> Agencies and teams managing more than one LinkedIn profile need a single dashboard. Logging in and out of accounts, or juggling multiple tool subscriptions, is a solved problem.</li>
-  <li><strong>Built-in scheduling:</strong> A workspace that requires you to export to a separate scheduler is not really a workspace. Scheduling should be native, timezone-aware, and tied directly to the post you just drafted.</li>
-  <li><strong>Analytics that feed back into creation:</strong> The most underrated feature of a good AI LinkedIn workspace is performance data that informs your next post — not just a scorecard for the last one.</li>
-  <li><strong>Reasonable pricing:</strong> The best tools for creators don't require a business-tier budget. Look for a free tier to validate the workflow, with paid plans that scale with your volume.</li>
-</ul>
+[Marquill's AI LinkedIn workspace](https://marquill.com) starts with research. You pick a post type, enter a topic, and it pulls context from YouTube to generate a LinkedIn-ready draft. From there, editing, account selection, and scheduling happen in the same tab.
 
-<h2>How Marquill Approaches the Workspace Problem</h2>
+No copy-pasting. No context-switching. **The gap between idea and published post gets as small as possible.**
 
-<p><a href="https://marquill.com">Marquill's AI LinkedIn workspace</a> is built around a single premise: the gap between having an idea and having a published post should be as small as possible.</p>
+## The bottom line
 
-<p>The workflow starts with research. You select a post type, enter your topic, and Marquill pulls context from YouTube to build a LinkedIn-length draft calibrated to your voice. From there, editing, image attachment, account selection, and scheduling all happen inside the same interface. Analytics from previous posts are visible when you're writing the next one.</p>
+There's no prize for using the most tools. If your current setup is working, stick with it. But if you're spending more time managing software than writing, a dedicated **AI LinkedIn workspace** is worth two weeks of your time.
 
-<p>The result is a faster publishing cycle — less time on tooling, more time on the ideas that actually matter.</p>
+Start on the free plan. Run it alongside your current setup. Let the publishing speed tell you if it's better.
 
-<h2>The Verdict</h2>
-
-<p>There's no award for using the most tools. If your current patchwork workflow is working, that's fine. But if you're spending more time managing software than actually writing, it's worth trying a proper <strong>AI LinkedIn workspace</strong> designed for the job.</p>
-
-<p>The best workspace in 2026 is the one you'll actually use consistently. Start with a free plan, run it alongside your existing setup for two weeks, and let the publishing speed speak for itself.</p>
-    `,
+[Try Marquill free →](https://marquill.com)
+    `.trim(),
   },
   {
     slug: 'linkedin-content-workflow-ai-workspace',
@@ -67,74 +61,78 @@ export const posts: Post[] = [
     date: '2026-04-08',
     readTime: '7 min read',
     content: `
-<p>The creators who publish consistently on LinkedIn aren't necessarily the ones with the most ideas. They're the ones with the best system. A repeatable workflow removes the decision fatigue from publishing — you always know what step comes next, and the tools handle the rest.</p>
+The people posting consistently on LinkedIn aren't the ones with the most ideas. They're the ones with the best system.
 
-<p>This guide walks through how to build that workflow using an <strong>AI LinkedIn workspace</strong>, from the first spark of an idea to a post that's scheduled and going out at the right time.</p>
+**A good workflow removes the decisions.** You always know what comes next — and the tools handle the execution.
 
-<h2>Step 1 — Set Your Publishing Cadence First</h2>
+Here's how to build that system using an **AI LinkedIn workspace**, from blank page to published post.
 
-<p>Before touching any tool, decide how often you want to publish. Three times a week is a common target for creators who want consistent growth. Once a week is sustainable for most founders with full-time responsibilities. Daily posting is achievable with the right workspace, but rarely necessary to build an audience.</p>
+## Step 1 — Pick your cadence before anything else
 
-<p>The number matters less than the consistency. Pick a cadence you can hold for 90 days without burning out, then design your workflow around it.</p>
+Decide how often you're actually going to post. Not how often you want to. How often you'll *still* be doing in 90 days.
 
-<h2>Step 2 — Build a Topic Bank</h2>
+- **3x per week** — solid for consistent growth
+- **1x per week** — sustainable for most founders with full schedules
+- **Daily** — achievable with the right workspace, rarely necessary
 
-<p>A topic bank is a running list of ideas separated from the drafting process. It prevents the blank-page problem and decouples ideation (which is creative work) from writing (which is execution work).</p>
+Consistency beats volume. A realistic cadence you can hold beats an ambitious one you'll drop.
 
-<p>Good sources for LinkedIn topics:</p>
+## Step 2 — Keep a topic bank (separate from drafting)
 
-<ul>
-  <li>Questions your audience asks you repeatedly</li>
-  <li>Hard lessons from recent projects or client engagements</li>
-  <li>Contrarian takes on common advice in your industry</li>
-  <li>Data or observations from your own work that others would find surprising</li>
-  <li>YouTube videos or podcasts in your niche that sparked a reaction</li>
-</ul>
+A topic bank is just a running list of ideas you collect *before* you need to write. It solves the blank-page problem and keeps ideation and execution separate.
 
-<p>The last point is worth expanding on. An <a href="https://marquill.com">AI LinkedIn workspace like Marquill</a> connects directly to YouTube research, so you can start a post from a video you watched rather than a blank document. You select the post type, add your topic or a video reference, and the AI generates a LinkedIn-ready draft from that source material.</p>
+Good sources for topics:
 
-<h2>Step 3 — Draft in the Workspace, Not in a Separate Doc</h2>
+- Questions you get asked repeatedly
+- Hard lessons from recent projects
+- Contrarian takes on advice in your field
+- Data from your own work that others would find surprising
+- YouTube videos in your niche that sparked a reaction
 
-<p>The most common workflow inefficiency is drafting in Google Docs or Notion, then copying the finished post into a scheduler. This sounds minor, but it creates a separate "finishing" step that becomes a bottleneck, especially when you're in a rhythm and don't want to context-switch.</p>
+That last one is worth noting — [Marquill](https://marquill.com) connects directly to YouTube research, so you can start a post from a video instead of a blank document.
 
-<p>A proper AI LinkedIn workspace lets you draft, edit, and schedule in the same environment. The AI generates a starting point, you refine it, attach an image, select which LinkedIn account it posts from, pick a time, and queue it — all without leaving the tab.</p>
+## Step 3 — Draft and schedule in the same place
 
-<h2>Step 4 — Edit for Voice, Not from Scratch</h2>
+The most common workflow bottleneck: drafting in Notion or Google Docs, then copy-pasting into a scheduler. It sounds small. It becomes a real friction point when you're in a rhythm.
 
-<p>AI-generated drafts should be a starting point, not a finished product. The most important editing pass is for voice — making the post sound like you, not like a language model that has read every LinkedIn post ever written.</p>
+**A proper AI LinkedIn workspace lets you draft, edit, and schedule without leaving the tab.** Pick your post type, generate a draft, refine it, attach an image, select your account, set a time. Done.
 
-<p>Practical voice edits:</p>
+## Step 4 — Edit for your voice, not from scratch
 
-<ul>
-  <li>Replace the opening line. AI hooks tend to be generic. Write your own.</li>
-  <li>Cut filler phrases ("In today's fast-paced world…", "It's important to note…").</li>
-  <li>Add a specific detail, number, or anecdote that only you would know.</li>
-  <li>Shorten. LinkedIn posts rarely benefit from being longer than they are.</li>
-</ul>
+AI drafts are a starting point, not a final product. The most important edit is voice — making it sound like *you*, not like every other AI-generated LinkedIn post.
 
-<h2>Step 5 — Schedule at Peak Times for Your Audience</h2>
+Quick voice edits that actually matter:
 
-<p>Once the post is edited, scheduling is the easy part — but it's worth doing intentionally. Tuesday through Thursday mornings (7–9am in your audience's primary timezone) tend to perform well for most B2B LinkedIn audiences. Your own analytics will tell you if your audience skews differently.</p>
+- **Rewrite the first line.** AI hooks tend to be generic. Yours shouldn't be.
+- **Cut filler phrases** — "In today's competitive landscape…", "It's important to note…"
+- **Add one specific detail** — a number, a name, an outcome — that only you would know.
+- **Shorten it.** LinkedIn posts almost never get better by being longer.
 
-<p>A timezone-aware scheduler inside your AI LinkedIn workspace handles the UTC conversion automatically, so you set local times and don't have to calculate the offset yourself.</p>
+## Step 5 — Schedule with intention
 
-<h2>Step 6 — Review Analytics Weekly, Not Daily</h2>
+Tuesday–Thursday mornings (7–9am in your audience's timezone) tend to work well for B2B LinkedIn. Your analytics will tell you if your audience skews differently.
 
-<p>Checking post performance daily is a distraction. The signal-to-noise ratio is too low — a post that looks weak at 6 hours can outperform another at 48 hours once the algorithm catches up.</p>
+A timezone-aware scheduler handles the offset math automatically. You set the local time, it handles the rest.
 
-<p>Instead, review the previous week's posts every Monday. Note what formats got the highest engagement, which hooks generated the most comments, and which topics drove profile views. Feed those observations back into your topic bank and into the briefs you give the AI.</p>
+## Step 6 — Review analytics weekly, not daily
 
-<h2>The Workflow in Summary</h2>
+Checking your post performance every few hours is a distraction. The signal-to-noise is too low — a post that looks weak at 6 hours can outperform everything else at 48.
 
-<ul>
-  <li><strong>Sunday:</strong> Review analytics from the past week. Refresh the topic bank.</li>
-  <li><strong>Monday:</strong> Draft the week's posts in the AI workspace. Edit for voice.</li>
-  <li><strong>Monday afternoon:</strong> Schedule all posts for the week. Attach images.</li>
-  <li><strong>Throughout the week:</strong> Engage with comments. Note observations for next week.</li>
-</ul>
+Instead: review the past week every Monday. Note what formats got the most engagement, which hooks drove comments, which topics drove profile visits. Feed that back into your topic bank.
 
-<p>The whole system, once set up inside an <a href="https://marquill.com">AI LinkedIn workspace</a>, takes 2–3 hours per week. The consistency it creates compounds over time in ways that ad hoc posting never does.</p>
-    `,
+## The weekly system at a glance
+
+| Day | Task |
+|---|---|
+| Sunday | Review analytics. Refresh topic bank. |
+| Monday | Draft the week's posts. Edit for voice. |
+| Monday PM | Schedule all posts. Attach images. |
+| Throughout week | Engage with comments. Collect new topic ideas. |
+
+Once you've set this up inside an [AI LinkedIn workspace](https://marquill.com), the whole thing takes about 2–3 hours a week. The consistency compounds over time in a way that ad hoc posting never does.
+
+[Start building your system →](https://marquill.com)
+    `.trim(),
   },
   {
     slug: 'why-linkedin-posts-not-getting-traction',
@@ -144,54 +142,66 @@ export const posts: Post[] = [
     date: '2026-04-06',
     readTime: '6 min read',
     content: `
-<p>You've written the post, checked it three times, hit publish — and then watched it get twelve impressions and two likes, one of which is your own. It's a familiar feeling for anyone building a presence on LinkedIn, and it's frustrating enough that most people quietly stop posting.</p>
+You hit publish. Twelve impressions. Two likes — one of which is yours. You refresh once more, close the tab, and quietly wonder if it's worth it.
 
-<p>The good news: flat posts are rarely a problem with your ideas. They're almost always a structural problem — something in the way the post is formatted, hooked, or distributed that's working against you.</p>
+Here's the thing: **flat posts are almost never a problem with your ideas.** They're a structural problem — something in your hook, format, or consistency that's working against you.
 
-<p>Here's what's usually going wrong, and how a proper <strong>AI LinkedIn workspace</strong> addresses each issue.</p>
+Here's what's actually going wrong, and how a proper **AI LinkedIn workspace** fixes it.
 
-<h2>Problem 1 — The First Line Doesn't Stop the Scroll</h2>
+## Your first line doesn't earn the scroll
 
-<p>LinkedIn's feed shows roughly the first line or two of a post before the "see more" cutoff. If that opening doesn't give someone a reason to expand it, they keep scrolling. Most posts open with context-setting ("I've been thinking about…") or vague promises ("Here's what I learned after 10 years…") that don't earn the click.</p>
+LinkedIn shows roughly the first 1–2 lines before the "see more" cut. If that opening doesn't give someone a reason to keep reading, they're gone.
 
-<p>A strong opening makes a specific claim, asks a sharp question, or states a counterintuitive fact. It gives the reader something to react to before they even decide whether to read further.</p>
+Most posts open with:
 
-<p>An AI LinkedIn workspace trained on high-performing posts generates hooks calibrated to LinkedIn's format — short, punchy, and front-loaded with the payoff. You still need to edit for your voice, but the starting point is structurally sound.</p>
+- "I've been thinking about this a lot lately…"
+- "Here's what I learned after 10 years in [industry]…"
+- "Something interesting happened this week…"
 
-<h2>Problem 2 — Inconsistent Posting Frequency</h2>
+None of that earns the click. **A strong opener makes a specific claim, states a counterintuitive fact, or asks a sharp question.** It gives the reader something to react to before they even decide to keep going.
 
-<p>LinkedIn's algorithm rewards accounts that post consistently. A burst of five posts in one week followed by three weeks of silence is worse than posting once a week, every week. The algorithm loses confidence in your account's reliability, and so does your audience.</p>
+An AI workspace trained on high-performing LinkedIn posts generates hooks built for this format — short, punchy, front-loaded. You still edit for your voice, but the structure is already right.
 
-<p>Consistency is a scheduling problem, not a creativity problem. When research, drafting, and scheduling live in the same <a href="https://marquill.com">AI LinkedIn workspace</a>, you can batch an entire week of posts in one session and have them publish automatically. The calendar stays full even when your schedule doesn't.</p>
+## You're posting in bursts, not consistently
 
-<h2>Problem 3 — Generic Content That Could Have Been Written by Anyone</h2>
+Five posts in one week, then silence for three. LinkedIn's algorithm treats that worse than one post a week, every week — it loses confidence in your account, and so does your audience.
 
-<p>The most scrolled-past posts on LinkedIn are the ones that say something broadly true in the most forgettable way possible. "Consistency is key." "Mindset matters." "Always be learning." These posts exist in everyone's feed and stand out in none of them.</p>
+**Consistency is a scheduling problem, not a creativity problem.** When drafting and scheduling live inside the same [AI LinkedIn workspace](https://marquill.com), you can batch an entire week of posts in one session. The calendar stays full even on the weeks your schedule doesn't.
 
-<p>What performs is specificity. A post about a decision you made that didn't work out. A process you built that solved a specific problem. A number from your own data that challenges a common assumption. These posts can only come from you — and that's exactly why they work.</p>
+## Your content could have been written by anyone
 
-<p>A good AI workspace doesn't replace that specificity; it surfaces it. When you start a post from a YouTube video, a topic prompt, or a previous observation, the AI gives you a structure to fill with your own details. The scaffold is generic; the content you layer onto it is not.</p>
+"Consistency is key." "Always be learning." "Mindset matters." These posts exist everywhere on LinkedIn and stand out nowhere.
 
-<h2>Problem 4 — No Clear Format</h2>
+What actually performs is *specificity*. A decision you made that didn't work. A process you built that solved a real problem. A number from your own work that challenges a common assumption. **Those posts can only come from you — and that's exactly why they work.**
 
-<p>The posts that consistently earn the highest engagement on LinkedIn follow recognizable formats: the list post, the story arc, the contrarian take, the how-to, the personal lesson. Readers know what they're getting, which lowers the cognitive load of deciding whether to read it.</p>
+A good AI workspace gives you structure to fill with your specific details. The scaffold is generic. What you layer onto it isn't.
 
-<p>Wandering posts — ones that start with one idea and drift into three others — lose readers midway because there's no payoff to wait for.</p>
+## Your post has no recognizable format
 
-<p>An <a href="https://marquill.com">AI LinkedIn workspace</a> lets you select a post type before generating the draft. That format selection does a lot of the structural work upfront, so you're editing a coherent piece rather than restructuring a rambling one.</p>
+The posts that consistently get the most engagement follow a format readers can recognize: the list, the story arc, the contrarian take, the how-to, the personal lesson.
 
-<h2>Problem 5 — You're Not Looking at What's Actually Working</h2>
+When a post starts somewhere and drifts into three different ideas, people drop off halfway because there's no payoff to wait for.
 
-<p>Most creators who post without momentum aren't reviewing their analytics with any intention. They check total impressions, feel vaguely good or bad, and move on. What they're missing is the specific data that tells them which formats are performing, which topics generate comments versus just views, and what time of day their audience is most active.</p>
+[Marquill](https://marquill.com) lets you select a post type before generating the draft. That one decision handles most of the structure — you're editing a coherent piece, not rebuilding a rambling one.
 
-<p>That data should be feeding back into every post you write. A workspace that shows you analytics alongside your drafts closes the loop between what you've published and what you write next.</p>
+## You're not actually using your analytics
 
-<h2>The Fix Is Structural</h2>
+Most people check their total impressions, feel vaguely good or bad, and move on. What they're missing:
 
-<p>Low LinkedIn traction is almost never a problem with the quality of your thinking. It's a problem with the system around the thinking — how you hook readers, how consistently you publish, whether your format is working, and whether you're learning from what you've already put out.</p>
+- Which formats are getting the most engagement
+- Which hooks generate comments vs. just views
+- Which topics are driving profile visits
 
-<p>An AI LinkedIn workspace addresses all of this in one environment. The research-to-draft pipeline removes the blank page problem. The scheduling tools handle consistency. The analytics close the feedback loop. What's left is the part only you can do: adding the specific details, the personal experience, and the point of view that no AI can generate for you.</p>
-    `,
+That data should feed directly into what you write next. A workspace that shows analytics alongside your drafts closes the loop — instead of guessing what's working, you know.
+
+## The fix is structural, not creative
+
+Low traction isn't a sign your thinking is weak. It's a sign the system around your thinking needs work — your hooks, your consistency, your format, your feedback loop.
+
+A proper **AI LinkedIn workspace** handles all of that in one place. What's left is the part only you can do: the specific experience, the real opinion, the point of view no AI can write for you.
+
+[Fix the structure — try Marquill free →](https://marquill.com)
+    `.trim(),
   },
   {
     slug: 'managing-multiple-linkedin-accounts-ai',
@@ -201,131 +211,140 @@ export const posts: Post[] = [
     date: '2026-04-04',
     readTime: '7 min read',
     content: `
-<p>Managing one LinkedIn account with a consistent publishing schedule is already a full-time job. Managing five — each with its own audience, voice, and posting goals — is a different challenge entirely.</p>
+Managing one LinkedIn account with a consistent posting schedule is already a lot. Managing five — each with its own audience, voice, and goals — is a different problem entirely.
 
-<p>For agencies handling LinkedIn content on behalf of clients, or for companies managing profiles across multiple team members, the operational complexity compounds fast. Who approves which post? How do you maintain different brand voices in the same workflow? Which account gets the next slot in the scheduler?</p>
+**The chaos isn't the content. It's the coordination.**
 
-<p>An <strong>AI LinkedIn workspace</strong> built for multi-account management changes the operational picture entirely. Here's how to use one effectively.</p>
+Who approves which post? How do you keep five different voices distinct? Which account gets the next scheduler slot? Without the right system, you end up drowning in tabs and spreadsheets.
 
-<h2>The Core Problem with Multi-Account LinkedIn Management</h2>
+Here's how to use an **AI LinkedIn workspace** to handle it without losing your mind.
 
-<p>Most LinkedIn tools are designed for a single user. Even platforms that nominally support multiple accounts bolt the feature on rather than building around it — you get a dropdown to switch between accounts, but drafts, analytics, and scheduling queues are still siloed per account.</p>
+## Why most tools aren't built for this
 
-<p>What agencies and teams actually need is a unified view: all accounts visible in one dashboard, drafts filterable by account, schedules visible across every profile, and analytics comparable across the accounts you manage. Without that unified view, the operational overhead of managing multiple accounts doesn't decrease with better tooling — it just shifts from one spreadsheet to another.</p>
+Most LinkedIn tools are designed for a single creator. Multi-account support is usually tacked on — a dropdown to switch between profiles, with drafts, queues, and analytics still siloed per account.
 
-<h2>Setting Up a Multi-Account Workspace</h2>
+What agencies and teams actually need:
 
-<p>The setup process in a proper <a href="https://marquill.com">AI LinkedIn workspace</a> starts with connecting LinkedIn profiles via OAuth. Each profile — whether a personal page, a company page, or a client account — is added to the workspace and becomes selectable at every stage of the drafting and scheduling process.</p>
+- All accounts visible in one dashboard
+- Drafts filterable by account
+- Scheduling visible across every profile at once
+- Analytics comparable across accounts
 
-<p>The key workflow change: you draft first, then assign. Rather than opening a specific account's queue before writing, you write inside the workspace and select the account (or accounts) the post is intended for before scheduling. This means you can batch-produce content for multiple accounts in a single session without logging in and out of anything.</p>
+Without that unified view, better tooling doesn't reduce your workload — it just moves the spreadsheet.
 
-<h2>Maintaining Different Brand Voices</h2>
+## Setting up a multi-account workspace
 
-<p>The biggest editorial challenge in multi-account management is keeping voices distinct. A SaaS founder's LinkedIn presence sounds different from a law firm's company page, which sounds different from a freelance consultant's personal profile — even if all three are being managed from the same desk.</p>
+In [Marquill](https://marquill.com), you connect LinkedIn profiles via OAuth — personal pages, company pages, client accounts. Each one becomes selectable at every stage of the drafting and scheduling process.
 
-<p>Practical approaches to maintaining voice differentiation in an AI workspace:</p>
+**The key shift: draft first, assign second.** You don't open a specific account's queue before writing. You write inside the workspace, then choose which account (or accounts) the post goes to. That means you can batch-produce content for five accounts in one session, without logging in and out of anything.
 
-<ul>
-  <li><strong>Keep a voice brief per account.</strong> A short document (3–5 bullet points) describing the account's tone, the topics it covers, and phrases or formats it avoids. Reference this brief when reviewing AI drafts for that account.</li>
-  <li><strong>Use different post types by account.</strong> A company page might default to case studies and industry analysis. A founder's personal page might lead with personal stories and contrarian takes. Selecting the right post type when generating a draft does a lot of voice work upfront.</li>
-  <li><strong>Edit the first line for every account.</strong> The AI hook will be generic. Rewriting it in the specific voice of each account is the single highest-leverage editing pass you can make.</li>
-</ul>
+## Keeping voices distinct across accounts
 
-<h2>Scheduling at Scale</h2>
+This is the real editorial challenge. A SaaS founder sounds different from a law firm's company page, which sounds different from a freelance consultant — even if all three are managed from the same workspace.
 
-<p>With five accounts each posting three times a week, you're managing fifteen scheduled posts per week. That's before accounting for last-minute additions, client feedback loops, or time-sensitive content that needs to jump the queue.</p>
+Three things that actually help:
 
-<p>A workspace with a shared scheduling queue across accounts makes this manageable. You can see the full week's schedule across all accounts in one view, identify gaps, and fill them without switching contexts. Timezone-aware scheduling handles the complexity of clients in different regions without manual offset calculations.</p>
+- **Keep a voice brief per account.** 3–5 bullet points on tone, topics, and phrases to avoid. Reference it when reviewing AI drafts.
+- **Use different post types by account.** A company page might default to case studies. A founder's personal page might lead with stories and contrarian takes. Choosing the right format upfront does most of the voice work.
+- **Rewrite the first line for every account.** The AI hook will be generic. One targeted edit makes it sound like the right person wrote it.
 
-<h2>Reviewing Performance Across Accounts</h2>
+## Scheduling at scale
 
-<p>Single-account analytics tell you what's working for one audience. Multi-account analytics tell you what's working as a principle — patterns that hold across different accounts, industries, and audiences, and patterns that don't.</p>
+Five accounts, three posts each, every week — that's 15 scheduled posts. Before accounting for last-minute additions, client feedback, or time-sensitive content.
 
-<p>If carousel posts are outperforming text posts across three of your five accounts, that's a signal worth acting on across all five. If a specific hook format is driving unusually high comment rates on a client's account, that's a template worth stealing for others.</p>
+A shared scheduling view across all accounts makes this manageable. You see the full week at a glance, spot the gaps, and fill them without switching contexts. Timezone-aware scheduling handles the offset math for clients in different regions automatically.
 
-<p>Analytics reviewed across accounts, rather than in isolation, compound the learning faster than managing each profile independently.</p>
+## Using cross-account analytics
 
-<h2>Who This Is For</h2>
+Single-account analytics tell you what's working for one audience. Cross-account analytics tell you what's working *as a principle*.
 
-<p>Multi-account LinkedIn management with an AI workspace makes the most sense for:</p>
+If carousel posts are outperforming text posts across three of your five accounts, that's worth acting on across all five. **If a hook format is driving unusually high comment rates on one client's account, that's a template worth testing on the others.**
 
-<ul>
-  <li><strong>Content agencies</strong> managing LinkedIn presence for 3+ clients.</li>
-  <li><strong>Ghostwriting operations</strong> writing under multiple personal brand names.</li>
-  <li><strong>Growth teams</strong> managing a mix of founder profiles, company pages, and employee advocacy accounts.</li>
-  <li><strong>Consultants</strong> managing their own profile alongside a company page or a second personal brand.</li>
-</ul>
+## Who this setup actually makes sense for
 
-<p>If you're managing more than two LinkedIn accounts and spending more than two hours a week on scheduling and coordination, a dedicated <a href="https://marquill.com">AI LinkedIn workspace</a> will cut that time significantly — and produce more consistent output in the process.</p>
-    `,
+- Content agencies managing LinkedIn for 3+ clients
+- Ghostwriting operations managing multiple personal brands
+- Growth teams running founder profiles, company pages, and employee advocacy at once
+- Consultants managing their own profile alongside a client or company page
+
+If you're managing more than two LinkedIn accounts and spending more than two hours a week on coordination alone, a dedicated [AI LinkedIn workspace](https://marquill.com) will cut that time and produce more consistent output.
+
+[Try Marquill free →](https://marquill.com)
+    `.trim(),
   },
   {
     slug: 'taplio-vs-marquill-ai-linkedin-workspace',
     title: 'Taplio vs. Marquill: Which AI LinkedIn Workspace Is Right for You?',
     description:
-      "A straightforward comparison of Taplio and Marquill for LinkedIn creators — pricing, AI features, scheduling, and who each tool is best suited for.",
+      'A straightforward comparison of Taplio and Marquill for LinkedIn creators — pricing, AI features, scheduling, and who each tool is best suited for.',
     date: '2026-04-02',
     readTime: '5 min read',
     content: `
-<p>If you've been researching AI tools for LinkedIn, you've probably come across Taplio. It's been one of the more visible options in the LinkedIn content space for a few years, and it does a solid job of certain things. Marquill takes a different approach — and depending on what you actually need, one of them is a significantly better fit.</p>
+If you've been looking for an AI tool for LinkedIn, you've probably come across Taplio. It's one of the more established names in the space. [Marquill](https://marquill.com) takes a different approach — and depending on what you actually need, one of them is a noticeably better fit.
 
-<p>This comparison covers the key differences honestly. Neither tool is universally better. The right choice depends on what matters most to your workflow.</p>
+This is a straight comparison. No inflated claims. Just what's different and who each tool is built for.
 
-<h2>The Core Difference in Approach</h2>
+## The core difference
 
-<p>Taplio's primary angle is inspiration and post recycling — it surfaces trending LinkedIn content, lets you save posts you like, and generates content from those inspirations. It's designed around the idea that the best LinkedIn content comes from observing what's already working and iterating on it.</p>
+**Taplio** is built around inspiration and recycling. It surfaces trending LinkedIn content, lets you save posts you like, and generates new content from that inspiration library. The core idea: remix what's already working.
 
-<p>Marquill's approach is research-first. Rather than drawing from existing LinkedIn posts as inspiration, it pulls context from YouTube — videos in your niche, relevant topics, recent conversations — and uses that as the raw material for original drafts. The output is less derivative of what's already circulating on LinkedIn and more grounded in the source material you actually care about.</p>
+**Marquill** is built around research-first content. Instead of drawing from existing LinkedIn posts, it pulls context from YouTube — videos in your niche, topics you care about — and uses that as the raw material for original drafts. The output is grounded in real sources, not trend-watching.
 
-<p>If your content style is observation and commentary on LinkedIn trends, Taplio's inspiration feed will feel natural. If you prefer building original posts from primary sources, Marquill's YouTube research workflow fits better.</p>
+**If you like remixing what's already performing on LinkedIn, Taplio fits your style. If you prefer building original content from primary sources, Marquill fits better.**
 
-<h2>AI Post Generation</h2>
+## AI post generation
 
-<p><strong>Taplio:</strong> Generates posts based on topics you enter, with the option to draw from posts you've saved to your inspiration library. The AI is capable and produces reasonable LinkedIn-format drafts. The output leans toward formats that are already popular on the platform, which is a strength if you want proven structures and a limitation if you want to differentiate.</p>
+| Feature | Taplio | Marquill |
+|---|---|---|
+| Source of inspiration | LinkedIn inspiration library | YouTube research + your topic |
+| Output style | Popular LinkedIn formats | Research-grounded drafts |
+| Customization | Topic prompts, tone settings | Post type selection + research context |
+| Voice editing needed | Yes | Yes |
 
-<p><strong>Marquill:</strong> Generates posts from a topic prompt combined with YouTube research context. The resulting drafts are more grounded in specific information rather than general advice, which tends to produce more original content. The tradeoff is that the research step adds a small amount of friction at the start of each session.</p>
+Both tools produce decent first drafts. The difference is where they pull from — and that shapes how original the output feels.
 
-<h2>Multi-Account Management</h2>
+## Multi-account support
 
-<p><strong>Taplio:</strong> Multi-account support exists but is primarily aimed at individual creators managing a single brand. Team features are available on higher-tier plans.</p>
+**Taplio** is primarily designed for individual creators. Team features exist on higher-tier plans, but multi-account management isn't a core focus.
 
-<p><strong>Marquill:</strong> Multi-account management is a core feature, not an add-on. Connecting personal profiles and company pages, filtering drafts and schedules by account, and managing publishing across multiple LinkedIn presences from a single dashboard is built into the <a href="https://marquill.com">AI LinkedIn workspace</a> from the start.</p>
+**Marquill** was built with multi-account management as a core feature from day one. Personal profiles, company pages, client accounts — all connected in one dashboard, with drafts and schedules filterable by account.
 
-<h2>Scheduling</h2>
+If you manage more than one LinkedIn presence, this is a meaningful difference.
 
-<p>Both tools offer LinkedIn post scheduling with timezone-aware publishing. This is table-stakes functionality at this point and neither has a meaningful advantage here. Marquill's scheduling is native to the drafting flow — you schedule a post immediately after editing it without switching screens. Taplio's scheduling is similarly integrated.</p>
+## Pricing
 
-<h2>Pricing</h2>
+| Plan | Taplio | Marquill |
+|---|---|---|
+| Free tier | Trial only | Free forever (1 account, 5 posts/mo) |
+| Entry paid | ~$39/mo | $9.99/mo |
+| Mid tier | ~$65/mo | $19.99/mo |
+| Agency/team | ~$199/mo | $29.99/mo (10 accounts) |
 
-<p><strong>Taplio</strong> starts at around $39/month and does not offer a permanent free tier — there's a trial period, but continued use requires a paid plan.</p>
+Marquill is significantly cheaper at every tier. Taplio's pricing reflects a more established product with a larger user base. Whether that premium is worth it depends on whether you actually need what Taplio does differently.
 
-<p><strong>Marquill</strong> offers a free plan (1 account, 5 AI posts per month) with paid plans starting at $9.99/month. The Creator plan at $19.99/month covers 2 accounts and 100 AI posts per month. For agencies, the Pro Writer plan at $29.99/month includes 10 accounts and unlimited posts.</p>
+## Who should pick which
 
-<p>For creators testing the waters or working with a limited budget, Marquill's free tier and lower entry price make it the more accessible starting point. Taplio's higher price point is harder to justify unless you're specifically drawn to its inspiration and trend-monitoring features.</p>
+**Go with Taplio if:**
 
-<h2>Who Each Tool Is Best For</h2>
+- Your strategy is built around monitoring LinkedIn trends and iterating on popular formats
+- You want a large saved inspiration library to draw from
+- You have the budget and want a tool with a bigger community
 
-<p><strong>Choose Taplio if:</strong></p>
-<ul>
-  <li>Your content strategy relies heavily on monitoring LinkedIn trends and remixing popular formats.</li>
-  <li>You want a large library of saved inspiration posts to draw from.</li>
-  <li>Budget is less of a concern and you want a more established tool with a larger user base.</li>
-</ul>
+**Go with Marquill if:**
 
-<p><strong>Choose Marquill if:</strong></p>
-<ul>
-  <li>You want an <a href="https://marquill.com">AI LinkedIn workspace</a> that generates content from primary source research rather than existing LinkedIn posts.</li>
-  <li>You manage multiple LinkedIn accounts and need genuine multi-account support in the core product.</li>
-  <li>You want to start on a free plan before committing, or you want a lower-cost paid option.</li>
-  <li>You value a focused, workflow-first tool over a feature-heavy platform.</li>
-</ul>
+- You want an [AI LinkedIn workspace](https://marquill.com) that generates content from real research, not LinkedIn recycling
+- You manage multiple accounts and need genuine multi-account support in the base product
+- You want to start free before committing, or you want lower-cost paid plans
+- You prefer a focused, workflow-first tool over a feature-heavy platform
 
-<h2>The Bottom Line</h2>
+## The short version
 
-<p>Both Taplio and Marquill are legitimate AI LinkedIn workspaces that will improve your publishing consistency and content quality compared to no tool at all. The choice comes down to your content philosophy and your budget.</p>
+Both tools will make your LinkedIn publishing more consistent. The question is your content philosophy.
 
-<p>If you produce original content grounded in research and ideas rather than LinkedIn trend-watching, Marquill's workflow fits better and costs significantly less. Start with the free plan and see whether the YouTube research-to-draft pipeline clicks for how you actually work.</p>
-    `,
+If you build content from ideas and research rather than trend-watching, Marquill's workflow fits better — and costs a lot less. Start on the free plan and see if the YouTube research-to-draft pipeline clicks for how you actually work.
+
+[Try Marquill free →](https://marquill.com)
+    `.trim(),
   },
 ];
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lucide-react": "^0.460.0",
     "next": "16.1.6",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary

- **SEO overhaul** — Added `robots.txt`, `sitemap.xml`, `metadataBase`, JSON-LD structured data, and workspace-focused keyword targeting across homepage, pricing, and privacy policy pages
- **Blog** — New blog at `/blog` with 5 SEO-targeted posts (AI LinkedIn workspace keyword cluster), rendered via ReactMarkdown with remark-gfm; posts rewritten in Gen Z professional voice — short paragraphs, direct hooks, skimmable layout
- **Paddle checkout** — Inline checkout page at `/checkout` using Paddle Billing JS SDK; reads `priceId`, `tierName`, `monthlyPrice`, and `userId` from query params; pre-fills customer from `user` cookie; supports sandbox/production via `NEXT_PUBLIC_PADDLE_ENVIRONMENT`; global nav/footer hidden on checkout route
- **New pages** — Terms of Service (`/tsc`) and Refund Policy (`/refund`)
- **Pricing update** — Free / $9.99 / $19.99 / $29.99 tiers across homepage and pricing page
- **Brand fix** — Replaced all "inContentai" references with Marquill throughout metadata and body copy
- **Nav cleanup** — Removed language selector from desktop and mobile nav

## Test plan

- [ ] Visit `/blog` — posts render as cards with correct titles and dates
- [ ] Visit a blog post — markdown renders correctly (headings, bold, lists, tables, links)
- [ ] Visit `/checkout?priceId=pri_xxx&tierName=Creator&monthlyPrice=19.99&userId=abc` — Paddle inline widget loads, global nav is hidden
- [ ] Visit `/tsc` and `/refund` — pages render with correct content and footer links work
- [ ] Visit `/pricing` — four tiers display at correct prices
- [ ] Check `out/robots.txt` and `out/sitemap.xml` exist after `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)